### PR TITLE
Enable custom title attribute for novel extension.

### DIFF
--- a/lib/views/pages/watch/reader/novel/novel_reader_content.dart
+++ b/lib/views/pages/watch/reader/novel/novel_reader_content.dart
@@ -70,7 +70,7 @@ class _NovelReaderContentState extends State<NovelReaderContent> {
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 20),
                     child: Text(
-                      _c.title + _c.playList[_c.playIndex].name,
+                      watchData.title,
                       style: const TextStyle(fontSize: 26),
                     ),
                   );

--- a/lib/views/pages/watch/reader/novel/novel_reader_content.dart
+++ b/lib/views/pages/watch/reader/novel/novel_reader_content.dart
@@ -70,7 +70,7 @@ class _NovelReaderContentState extends State<NovelReaderContent> {
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 20),
                     child: Text(
-                      watchData.title,
+                      _c.playList[_c.index.value].name,
                       style: const TextStyle(fontSize: 26),
                     ),
                   );

--- a/lib/views/pages/watch/reader/novel/novel_reader_content.dart
+++ b/lib/views/pages/watch/reader/novel/novel_reader_content.dart
@@ -76,15 +76,16 @@ class _NovelReaderContentState extends State<NovelReaderContent> {
                   );
                 }
                 if (index == 1) {
-                  return (watchData.subtitle != null)
-                      ? Padding(
-                          padding: const EdgeInsets.only(bottom: 20),
-                          child: Text(
-                            watchData.subtitle!,
-                            style: const TextStyle(fontSize: 20),
-                          ),
-                        )
-                      : const SizedBox();
+                  return const SizedBox();
+                  // return (watchData.subtitle != null)
+                  //     ? Padding(
+                  //         padding: const EdgeInsets.only(bottom: 20),
+                  //         child: Text(
+                  //           watchData.subtitle!,
+                  //           style: const TextStyle(fontSize: 20),
+                  //         ),
+                  //       )
+                  //     : const SizedBox();
                 }
                 return Padding(
                   padding: const EdgeInsets.only(bottom: 20),


### PR DESCRIPTION
作为一个Miru的扩展开发者，我忍这个title属性很久了，明明可以返回小说章节的大标题却不用，非要用小说名+章节名拼接，而且在切换下一章的时候用的还是上一章的标题，我还以为是自己写的扩展没生效😥

原来的Miru目前应该是停摆了，大部分的issue都没回应，感谢您的分支能给我改动的机会，祝您越做越好🙏